### PR TITLE
Cheerioschelsea patch 5

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,10 +1,10 @@
 {
-	"name": "Pokémon Platinum AP Manual Tracker",
+	"name": "Pokémon Platinum Tracker V4",
 	"game_name": "Manual_PokemonPlatinum_Linneus",
 	"package_version": "0.1.2",
 	"min_poptracker_version": "0.27.1",
 	"package_uid": "manual_pokemonplatinum_linneus_ap",
-	"author": "ZobeePlays (Sophie), darkfire006, cheerioschelsea & palex00",
+	"author": "ZobeePlays (Sophie), palex00, darkfire006, & cheerioschelsea",
 	"variants": {
 		"Map Tracker": {
 			"display_name": "Map Tracker",

--- a/manifest.json
+++ b/manifest.json
@@ -1,19 +1,18 @@
-
 {
-    "name": "Pokémon Platinum Tracker V4",
-    "game_name": "Pokémon Platinum",
-    "package_version": "0.1.0",
-	"min_poptracker_version": "0.27.0",
-    "package_uid": "manual_pokemonplatinum_linneus_ap",
-    "author": "ZobeePlays (Sophie), palex00, darkfire006, & cheerioschelsea",
-    "variants": {
-        "Map Tracker": {
-            "display_name": "Map Tracker",
-            "flags": ["ap"]
-        },
-        "Items Only": {
-            "display_name": "Items Only",
-            "flags": ["ap"]
-        }
-    }
+	"name": "Pokémon Platinum AP Manual Tracker",
+	"game_name": "Manual_PokemonPlatinum_Linneus",
+	"package_version": "0.1.2",
+	"min_poptracker_version": "0.27.1",
+	"package_uid": "manual_pokemonplatinum_linneus_ap",
+	"author": "ZobeePlays (Sophie), darkfire006, cheerioschelsea & palex00",
+	"variants": {
+		"Map Tracker": {
+			"display_name": "Map Tracker",
+			"flags": ["ap", "apmanual"]
+		},
+		"Items Only": {
+			"display_name": "Items Only",
+			"flags": ["ap", "apmanual"]
+		}
+	}
 }


### PR DESCRIPTION
added "apmanual" flag to support sending checks from the tracker.
updated pack version.
updated min poptracker version.

according to PopTracker https://github.com/black-sliver/PopTracker/blob/master/doc/PACKS.md
-- "apmanual": pack supports sending locations to Archipelago. Uses game_name as game.
so from what i understand, in order to send checks, game_name has to match the apworld name.